### PR TITLE
Bug fix/back to main

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,7 @@ function displayForm() {
 function goToMain(){
   mainPoster.hidden = false;
   posterForm.classList.add('hidden');
+  savedPosterPage.classList.remove('hidden');
 }
 
 function displaySavedPosters() {

--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,7 @@ function displayForm() {
 function goToMain(){
   mainPoster.hidden = false;
   posterForm.classList.add('hidden');
-  savedPosterPage.classList.remove('hidden');
+  savedPosterPage.classList.add('hidden');
 }
 
 function displaySavedPosters() {


### PR DESCRIPTION
The goToMain function was hard coded to only hide the form page and not to hide the saved poster page. There is now an added line that will hide that page.