### PR TITLE
Fix: allow users to see more than one saved poster

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -179,11 +179,11 @@ function displaySavedPosters() {
   mainPoster.hidden = true;
   savedPosterPage.classList.remove('hidden');
   for (var i = 0; i < savedPosters.length; i++) {
-    savedPosterGrid.innerHTML = `<article class='mini-poster'>
+    savedPosterGrid.insertAdjacentHTML('afterbegin', `<article class='mini-poster'>
       <img class='mini-poster img' src=${savedPosters[i].imageURL} alt='Your saved poster'> 
       <h2>${savedPosters[i].title}</h2> 
       <h4>${savedPosters[i].quote}</h4> 
-      </article>`;
+      </article>`);
   }
 }
 


### PR DESCRIPTION
In the displaySavedPosters function we replaced innerHTML with insertAdjacentHTML so that new mini posters are added into the grid instead of saved over the grid.