### PR TITLE
Fix: fix the saved posters duplication bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -173,6 +173,8 @@ function goToMain() {
   mainPoster.hidden = false;
   posterForm.classList.add('hidden');
   savedPosterPage.classList.add('hidden');
+
+  savedPosterGrid.innerHTML = "";
 }
 
 function displaySavedPosters() {


### PR DESCRIPTION
This code fixes the bug that caused the entire saved array to be displayed on the grid each time the grid was shown, resulting in duplicate posters on the grid. To fix this we cleared the entire grid each time the user returns to the main page.